### PR TITLE
Implement more JsonPath operators

### DIFF
--- a/src/commonMain/kotlin/io.github.nomisrev/JsonPath.kt
+++ b/src/commonMain/kotlin/io.github.nomisrev/JsonPath.kt
@@ -1,3 +1,4 @@
+@file:Suppress("TooManyFunctions", "InvalidPackageDeclaration")
 package io.github.nomisrev
 
 import arrow.core.Option
@@ -105,7 +106,7 @@ public fun Optional<JsonElement, JsonElement>.selectEvery(
     selector == "*" -> this compose Every.jsonElement() // inline definition of [every]
     ixs != null -> filterIndex { it in ixs }
     startIx != null -> filterIndex { it >= startIx }
-    startEndIx != null -> filterIndex { it >= startEndIx.first && it < startEndIx.second }
+    startEndIx != null -> get(startEndIx.first until startEndIx.second)
     else -> get(selector)
   }
 }
@@ -125,7 +126,7 @@ public fun Optional<JsonElement, JsonElement>.path(
   path.splitTwice(fieldDelimiter, indexDelimiter).fold(this) { acc, pathSelector -> acc.select(pathSelector) }
 
 /**
- * Select _path_ with multiple results, see [selectMultiple] for the allowed selectors
+ * Select _path_ with multiple results, see [selectEvery] for the allowed selectors
  *
  * ```kotlin
  * JsonPath.path("addresses[0].*.street.name")
@@ -167,6 +168,12 @@ public operator fun Optional<JsonElement, JsonElement>.get(
   index: Int
 ): Optional<JsonElement, JsonElement> =
   array compose Index.list<JsonElement>().index(index)
+
+/** Select all indices from the [range] out of a [JsonArray] */
+public operator fun Optional<JsonElement, JsonElement>.get(
+  range: ClosedRange<Int>
+): Every<JsonElement, JsonElement> =
+  filterIndex { it in range }
 
 /** Select an indices out of a [JsonArray] with the given [predicate] */
 public fun Optional<JsonElement, JsonElement>.filterIndex(

--- a/src/commonMain/kotlin/io.github.nomisrev/JsonPathEvery.kt
+++ b/src/commonMain/kotlin/io.github.nomisrev/JsonPathEvery.kt
@@ -1,3 +1,4 @@
+@file:Suppress("TooManyFunctions", "InvalidPackageDeclaration")
 package io.github.nomisrev
 
 import arrow.core.None
@@ -96,7 +97,7 @@ public fun Every<JsonElement, JsonElement>.selectEvery(
     selector == "*" -> this compose Every.jsonElement() // inline definition of [every]
     ixs != null -> filterIndex { it in ixs }
     startIx != null -> filterIndex { it >= startIx }
-    startEndIx != null -> filterIndex { it >= startEndIx.first && it < startEndIx.second }
+    startEndIx != null -> get(startEndIx.first until startEndIx.second)
     else -> get(selector)
   }
 }
@@ -116,7 +117,7 @@ public fun Every<JsonElement, JsonElement>.path(
   path.splitTwice(fieldDelimiter, indexDelimiter).fold(this) { acc, pathSelector -> acc.select(pathSelector) }
 
 /**
- * Select _path_ with multiple results, see [selectMultiple] for the allowed selectors
+ * Select _path_ with multiple results, see [selectEvery] for the allowed selectors
  *
  * ```kotlin
  * JsonPath.path("addresses[0].*.street.name")
@@ -152,6 +153,10 @@ public operator fun Every<JsonElement, JsonElement>.get(property: String): Every
 /** Select an [index] out of a [JsonArray] */
 public operator fun Every<JsonElement, JsonElement>.get(index: Int): Every<JsonElement, JsonElement> =
   array compose Index.list<JsonElement>().index(index)
+
+/** Select all indices from the [range] out of a [JsonArray] */
+public operator fun Every<JsonElement, JsonElement>.get(range: ClosedRange<Int>): Every<JsonElement, JsonElement> =
+  filterIndex { it in range }
 
 /** Select an indices out of a [JsonArray] with the given [predicate] */
 public fun Every<JsonElement, JsonElement>.filterIndex(

--- a/src/commonMain/kotlin/io.github.nomisrev/JsonPathEvery.kt
+++ b/src/commonMain/kotlin/io.github.nomisrev/JsonPathEvery.kt
@@ -68,9 +68,9 @@ public fun Every<JsonElement, JsonElement>.select(selector: String): Every<JsonE
   val inBrackets = matchNameInBrackets(selector)
   val ix = matchIndexInBrackets(selector)
   return when {
-    inBrackets != null -> `object` compose Index.map<String, JsonElement>().index(inBrackets)
+    inBrackets != null -> get(inBrackets)
     ix != null -> get(ix)
-    else -> `object` compose Index.map<String, JsonElement>().index(selector)
+    else -> get(selector)
   }
 }
 
@@ -84,7 +84,7 @@ public fun Every<JsonElement, JsonElement>.select(selector: String): Every<JsonE
  * - `[start:end]`: select the indices from `start` to (but not including) `end`,
  * - `[start:]`: select the indices from `start` to the end of the array.
  */
-public fun Every<JsonElement, JsonElement>.selectMultiple(
+public fun Every<JsonElement, JsonElement>.selectEvery(
   selector: String
 ): Every<JsonElement, JsonElement> {
   val inBrackets = matchNameInBrackets(selector)
@@ -92,12 +92,12 @@ public fun Every<JsonElement, JsonElement>.selectMultiple(
   val startIx = matchStartIndex(selector)
   val startEndIx = matchStartEndIndex(selector)
   return when {
-    inBrackets != null -> `object` compose Index.map<String, JsonElement>().index(inBrackets)
+    inBrackets != null -> get(inBrackets)
     selector == "*" -> this compose Every.jsonElement() // inline definition of [every]
     ixs != null -> filterIndex { it in ixs }
     startIx != null -> filterIndex { it >= startIx }
     startEndIx != null -> filterIndex { it >= startEndIx.first && it < startEndIx.second }
-    else -> `object` compose Index.map<String, JsonElement>().index(selector)
+    else -> get(selector)
   }
 }
 
@@ -122,12 +122,12 @@ public fun Every<JsonElement, JsonElement>.path(
  * JsonPath.path("addresses[0].*.street.name")
  * ```
  */
-public fun Every<JsonElement, JsonElement>.pathMultiple(
+public fun Every<JsonElement, JsonElement>.pathEvery(
   path: String,
   fieldDelimiter: String = ".",
   indexDelimiter: String = "["
 ): Every<JsonElement, JsonElement> =
-  path.splitTwice(fieldDelimiter, indexDelimiter).fold(this) { acc, pathSelector -> acc.selectMultiple(pathSelector) }
+  path.splitTwice(fieldDelimiter, indexDelimiter).fold(this) { acc, pathSelector -> acc.selectEvery(pathSelector) }
 
 /**
  * Select a property with a [name] as an [Option].
@@ -144,6 +144,10 @@ public fun Every<JsonElement, JsonElement>.filterKeys(
   predicate: (keys: String) -> Boolean
 ): Every<JsonElement, JsonElement> =
   `object` compose FilterIndex.map<String, JsonElement>().filter(predicate)
+
+/** Select a [property] out of a [JsonObject] */
+public operator fun Every<JsonElement, JsonElement>.get(property: String): Every<JsonElement, JsonElement> =
+  `object` compose Index.map<String, JsonElement>().index(property)
 
 /** Select an [index] out of a [JsonArray] */
 public operator fun Every<JsonElement, JsonElement>.get(index: Int): Every<JsonElement, JsonElement> =

--- a/src/commonMain/kotlin/io.github.nomisrev/selectUtils.kt
+++ b/src/commonMain/kotlin/io.github.nomisrev/selectUtils.kt
@@ -1,0 +1,50 @@
+package io.github.nomisrev
+
+/**
+ * Splits a string given those delimiters.
+ * [removedDelimiter] is removed after splitting,
+ * whereas [keptDelimiter] is kept around.
+ *
+ * For example, if we split `this[0].thing`
+ * we get back `listOf("this", "[0]", "thing")`.
+ */
+public fun String.splitTwice(
+  removedDelimiter: String = ".",
+  keptDelimiter: String = "["
+): List<String> =
+  split(removedDelimiter).flatMap {
+    when {
+      !it.contains('[') -> listOf(it)
+      it.startsWith('[') ->
+        // if it starts with '[', remove the first useless empty match
+        it.split(keptDelimiter).drop(1).map { keptDelimiter + it }
+      else -> {
+        // we know there's a '[', and not at the beginning
+        val (init, rest) = it.split(keptDelimiter, limit = 2)
+        listOf(init) + rest.split(keptDelimiter).map { keptDelimiter + it }
+      }
+    }
+  }
+
+// remember, group capture starts at 1, not at 0!
+public val MatchResult.firstMatch: String?
+  get() = groupValues.getOrNull(1)
+
+public fun matchIndexInBrackets(selector: String): Int? =
+  Regex("""\[([0-9]+)\]""").matchEntire(selector)?.firstMatch?.toInt()
+
+public fun matchIndicesInBrackets(selector: String): List<Int>? =
+  Regex("""\[([0-9]+(,[0-9]+)*)\]""").matchEntire(selector)?.firstMatch?.let {
+    it.split(',').map { it.toInt() }
+  }
+
+public fun matchStartIndex(selector: String): Int? =
+  Regex("""\[([0-9]+):\]""").matchEntire(selector)?.firstMatch?.toInt()
+
+public fun matchStartEndIndex(selector: String): Pair<Int, Int>? =
+  Regex("""\[([0-9]+):([0-9]+)\]""").matchEntire(selector)?.groupValues?.let {
+    it[1].toInt() to it[2].toInt()
+  }
+
+public fun matchNameInBrackets(selector: String): String? =
+  Regex("""\['([^']*)'\]""").matchEntire(selector)?.firstMatch

--- a/src/commonTest/kotlin/io/github/nomisrev/JsonDSLSpec.kt
+++ b/src/commonTest/kotlin/io/github/nomisrev/JsonDSLSpec.kt
@@ -116,6 +116,13 @@ class JsonDSLSpec : StringSpec({
     }
   }
 
+  "get from array, using get".config(enabled = platform != Platform.Native) {
+    checkAll(Arb.json(Arb.city())) { cityJson ->
+      JsonPath["streets"][0]["name"].string
+        .getOrNull(cityJson) shouldBe Json.decodeFromJsonElement(City.serializer(), cityJson).streets.getOrNull(0)?.name
+    }
+  }
+
   "get from array, using select with special syntax".config(enabled = platform != Platform.Native) {
     checkAll(Arb.json(Arb.city())) { cityJson ->
       JsonPath.select("['streets']").select("[0]")
@@ -134,7 +141,15 @@ class JsonDSLSpec : StringSpec({
 
   "get all elements from array".config(enabled = platform != Platform.Native) {
     checkAll(Arb.json(Arb.city())) { cityJson ->
-      JsonPath.pathMultiple("streets.*.name")
+      JsonPath.select("streets").selectEvery("*").select("name")
+        .string
+        .getAll(cityJson) shouldBe Json.decodeFromJsonElement(City.serializer(), cityJson).streets.map { it.name }
+    }
+  }
+
+  "get all elements from array, using path".config(enabled = platform != Platform.Native) {
+    checkAll(Arb.json(Arb.city())) { cityJson ->
+      JsonPath.pathEvery("streets.*.name")
         .string
         .getAll(cityJson) shouldBe Json.decodeFromJsonElement(City.serializer(), cityJson).streets.map { it.name }
     }

--- a/src/commonTest/kotlin/io/github/nomisrev/JsonDSLSpec.kt
+++ b/src/commonTest/kotlin/io/github/nomisrev/JsonDSLSpec.kt
@@ -123,6 +123,14 @@ class JsonDSLSpec : StringSpec({
     }
   }
 
+  "get from array, using get".config(enabled = platform != Platform.Native) {
+    checkAll(Arb.json(Arb.city())) { cityJson ->
+      JsonPath["streets"][0..0]["name"].string
+        .getAll(cityJson)
+        .getOrNull(0) shouldBe Json.decodeFromJsonElement(City.serializer(), cityJson).streets.getOrNull(0)?.name
+    }
+  }
+
   "get from array, using select with special syntax".config(enabled = platform != Platform.Native) {
     checkAll(Arb.json(Arb.city())) { cityJson ->
       JsonPath.select("['streets']").select("[0]")

--- a/src/commonTest/kotlin/io/github/nomisrev/JsonDSLSpec.kt
+++ b/src/commonTest/kotlin/io/github/nomisrev/JsonDSLSpec.kt
@@ -108,11 +108,35 @@ class JsonDSLSpec : StringSpec({
     }
   }
 
-  "get from array".config(enabled = platform != Platform.Native) {
+  "get from array, using select and get".config(enabled = platform != Platform.Native) {
     checkAll(Arb.json(Arb.city())) { cityJson ->
       JsonPath.select("streets")[0]
         .extract(Street.serializer())
         .getOrNull(cityJson) shouldBe Json.decodeFromJsonElement(City.serializer(), cityJson).streets.getOrNull(0)
+    }
+  }
+
+  "get from array, using select with special syntax".config(enabled = platform != Platform.Native) {
+    checkAll(Arb.json(Arb.city())) { cityJson ->
+      JsonPath.select("['streets']").select("[0]")
+        .extract(Street.serializer())
+        .getOrNull(cityJson) shouldBe Json.decodeFromJsonElement(City.serializer(), cityJson).streets.getOrNull(0)
+    }
+  }
+
+  "get from array, using path".config(enabled = platform != Platform.Native) {
+    checkAll(Arb.json(Arb.city())) { cityJson ->
+      JsonPath.path("streets[0]")
+        .extract(Street.serializer())
+        .getOrNull(cityJson) shouldBe Json.decodeFromJsonElement(City.serializer(), cityJson).streets.getOrNull(0)
+    }
+  }
+
+  "get all elements from array".config(enabled = platform != Platform.Native) {
+    checkAll(Arb.json(Arb.city())) { cityJson ->
+      JsonPath.pathMultiple("streets.*.name")
+        .string
+        .getAll(cityJson) shouldBe Json.decodeFromJsonElement(City.serializer(), cityJson).streets.map { it.name }
     }
   }
 })


### PR DESCRIPTION
This extends the available operators in `path` to include most of [this list](https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html).

In order to retain compatibility, the `select` and `path` only support those operations which select a single elements (array index, field name), whereas `selectMultiple` and `pathMultiple` also support those which return a list of values (like `*` to select all values in an object or array, or `[3:5]` to select indices from 3 to 5).

Of course, most of the time implementing this was spent on getting the regexes right 😅